### PR TITLE
feat: hilos de envío y recepción del cliente

### DIFF
--- a/src/chat/enviaClienteHilo.java
+++ b/src/chat/enviaClienteHilo.java
@@ -1,0 +1,32 @@
+package chat;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.util.Scanner;
+
+/**
+ * Hilo encargado de leer la entrada del teclado del cliente y enviarla al servidor.
+ */
+public class enviaClienteHilo extends Thread {
+    private Socket socket;
+
+    public enviaClienteHilo(Socket socket) {
+        this.socket = socket;
+    }
+
+    @Override
+    public void run() {
+        try (PrintWriter salida = new PrintWriter(socket.getOutputStream(), true);
+             Scanner teclado = new Scanner(System.in)) {
+            
+            String mensaje;
+            while (true) {
+                mensaje = teclado.nextLine();
+                salida.println(mensaje);
+            }
+        } catch (IOException e) {
+            System.err.println("Error en el hilo de envío del cliente: " + e.getMessage());
+        }
+    }
+}

--- a/src/chat/recibeClienteHilo.java
+++ b/src/chat/recibeClienteHilo.java
@@ -1,0 +1,29 @@
+package chat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+
+/**
+ * Hilo encargado de recibir mensajes del servidor y mostrarlos por pantalla.
+ */
+public class recibeClienteHilo extends Thread {
+    private Socket socket;
+
+    public recibeClienteHilo(Socket socket) {
+        this.socket = socket;
+    }
+
+    @Override
+    public void run() {
+        try (BufferedReader entrada = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+            String mensaje;
+            while ((mensaje = entrada.readLine()) != null) {
+                System.out.println("Servidor dice: " + mensaje);
+            }
+        } catch (IOException e) {
+            System.out.println("Conexión finalizada con el servidor.");
+        }
+    }
+}

--- a/src/chat/serverHilo.java
+++ b/src/chat/serverHilo.java
@@ -1,3 +1,5 @@
+package chat;
+
 import java.net.Socket;
 
 /**


### PR DESCRIPTION
Introduce two client-side thread classes: enviaClienteHilo (reads keyboard input and sends lines to the server via PrintWriter) and recibeClienteHilo (reads server messages via BufferedReader and prints them). Both use try-with-resources and basic IO error handling. 